### PR TITLE
Returned response code is always 200, and form method forcing

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -6,10 +6,11 @@ module Remotipart
     def render *args
       super
       if remotipart_submitted?
-        response.body = %{<textarea data-type=\"#{content_type}\">#{response.body}</textarea>}
+        response.body = %{<textarea data-type=\"#{content_type}\" response-code=\"#{response.response_code}\">#{response.body}</textarea>}
         response.content_type = Mime::HTML
       end
       response_body
     end
   end
 end
+

--- a/vendor/assets/javascripts/jquery.iframe-transport.js
+++ b/vendor/assets/javascripts/jquery.iframe-transport.js
@@ -113,7 +113,7 @@
     // based on the content type returned by the server, without attempting an
     // (unsupported) conversion from "iframe" to the actual type.
     options.dataTypes.shift();
-    
+
     if (files.length) {
       // Determine the form the file fields belong to, and make sure they all
       // actually belong to the same form.
@@ -170,6 +170,9 @@
       addedFields.push($("<input type='hidden' name='X-Http-Accept'>")
         .attr("value", accepts).appendTo(form));
 
+      addedFields.push($("<input type='hidden' name='_method'>")
+        .attr("value", options.type).appendTo(form));
+
       return {
 
         // The `send` function is called by jQuery when the request should be
@@ -177,7 +180,7 @@
         send: function(headers, completeCallback) {
           iframe = $("<iframe src='javascript:false;' name='iframe-" + $.now()
             + "' style='display:none'></iframe>");
-          
+
           // The first load event gets fired after the iframe has been injected
           // into the DOM, and is used to prepare the actual submission.
           iframe.bind("load", function() {
@@ -187,14 +190,14 @@
             // actual payload is embedded in a `<textarea>` element, and
             // prepares the required conversions to be made in that case.
             iframe.unbind("load").bind("load", function() {
-              
+
               var doc = this.contentWindow ? this.contentWindow.document :
                 (this.contentDocument ? this.contentDocument : this.document),
                 root = doc.documentElement ? doc.documentElement : doc.body,
                 textarea = root.getElementsByTagName("textarea")[0],
                 type = textarea ? textarea.getAttribute("data-type") : null;
-              
-              var status = 200,
+
+              var status = textarea ? parseInt(textarea.getAttribute("response-code")) : 200,
                 statusText = "OK",
                 responses = { text: type ? textarea.value : root ? root.innerHTML : null },
                 headers = "Content-Type: " + (type || "text/html")
@@ -203,7 +206,7 @@
 
               setTimeout(cleanUp, 50);
             });
-            
+
             // Now that the load handler has been set up, reconfigure and
             // submit the form.
             form.attr("action", options.url)


### PR DESCRIPTION
Two micro-pull requests in one here:
- `iframe.js` currently doesn't take care of the jQuery Ajax `type` setting (the method type for the request will remain the one specified on the form that contains the file upload fields;
- `iframe.js` always returns a 200 response status code, regardless of the original response code. i'm proposing a a small extension to the "standard" iframe protocol. I just added a `status-code` attribute to the `textarea` contained on the server response.

Let me know what you think about this! Thanks for your time.
