### PR TITLE
allow non-script responses

### DIFF
--- a/vendor/assets/javascripts/jquery.remotipart.js
+++ b/vendor/assets/javascripts/jquery.remotipart.js
@@ -23,7 +23,7 @@
           settings.processData = false;
 
           // Modify some settings to integrate JS request with rails helpers and middleware
-          if (settings.dataType === undefined) { settings.dataType = 'script *'; }
+          if (settings.dataType === undefined) { settings.dataType = '*'; }
           settings.data.push({name: 'remotipart_submitted', value: true});
 
           // Allow remotipartSubmit to be cancelled if needed


### PR DESCRIPTION
allow non-script responses. with script jquery 1.6.2 always processes the response as javascript resulting in a parse error if the response type is text/html

Signed-off-by: Joel Nimety jnimety@continuity.net
