### PR TITLE
patch #render to allow for </textarea> (closing tag) within content

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -7,7 +7,7 @@ module Remotipart
     def render *args
       super
       if remotipart_submitted?
-        response.body = %{<textarea data-type=\"#{content_type}\">#{escape_once(response.body)}</textarea>}
+        response.body = %{<textarea data-type=\"#{content_type}\" response-code=\"#{response.response_code}\">#{escape_once(response.body)}</textarea>}
         response.content_type = Mime::HTML
       end
       response_body


### PR DESCRIPTION
when rendering JSON with html containing a </textarea> tag, the <textarea> transport would close early.  i wrapped the content with a call to #escape_once, which resolves the issue.
- corey
