### PR TITLE
Fix confilcts with other Gems

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -4,8 +4,14 @@ module Remotipart
   module RenderOverrides
     include ActionView::Helpers::TagHelper
 
-    def render *args
-      super
+    def self.included(base)
+      base.class_eval do
+        alias_method_chain :render, :remotipart
+      end
+    end
+
+    def render_with_remotipart *args
+      render_without_remotipart *args
       if remotipart_submitted?
         response.body = %{<textarea data-type=\"#{content_type}\" response-code=\"#{response.response_code}\">#{escape_once(response.body)}</textarea>}
         response.content_type = Mime::HTML


### PR DESCRIPTION
If we use remotipart with wicked_pdf, the javascript returned by create.js.erb won't be executed after the request.

When using alias_method_chain, we let another gem to be able to override the "render" method on ActionController::Base.
