### PR TITLE
jQuery 1.9 compatibility

### DIFF
--- a/vendor/assets/javascripts/jquery.remotipart.js
+++ b/vendor/assets/javascripts/jquery.remotipart.js
@@ -51,7 +51,7 @@
     }
   };
 
-  $('form').live('ajax:aborted:file', function(){
+  $(document).on('ajax:aborted:file', 'form', function(){
     var form = $(this);
 
     remotipart.setup(form);


### PR DESCRIPTION
jQuery doesn’t support `$.fn.live anymore`. We should use `$.fn.on(event, selector, callback)`.
