### PR TITLE
removes deprecated jquery .live() and replace it with new .on() for jquery 1.9

### DIFF
--- a/vendor/assets/javascripts/jquery.remotipart.js
+++ b/vendor/assets/javascripts/jquery.remotipart.js
@@ -51,7 +51,7 @@
     }
   };
 
-  $('form').live('ajax:aborted:file', function(){
+  $('form').on('ajax:aborted:file', function(){
     var form = $(this);
 
     remotipart.setup(form);


### PR DESCRIPTION
Rails 3.2 using jquery 1.9. The .live() function is deprecated since jquery 1.7. The new function is .on().
