### PR TITLE
Fix jQuery 1.9 issues

### DIFF
--- a/vendor/assets/javascripts/jquery.remotipart.js
+++ b/vendor/assets/javascripts/jquery.remotipart.js
@@ -20,6 +20,15 @@
           settings.iframe      = true;
           settings.files       = $($.rails.fileInputSelector, form);
           settings.data        = form.serializeArray();
+          
+          // jQuery 1.9 serializeArray() contains input:file entries
+          // so exclude them from settings.data, otherwise files will not be sent
+          settings.files.each(function(i, file){
+            for (var j = settings.data.length - 1; j >= 0; j--)
+              if (settings.data[j].name == file.name)
+                settings.data.splice(j, 1);
+          })
+          
           settings.processData = false;
 
           // Modify some settings to integrate JS request with rails helpers and middleware
@@ -51,7 +60,7 @@
     }
   };
 
-  $('form').live('ajax:aborted:file', function(){
+  $(document).on('ajax:aborted:file', 'form', function(){
     var form = $(this);
 
     remotipart.setup(form);


### PR DESCRIPTION
1. Use jQuery.on(...) instead of deprecated jQuery.live(...)
2. Remove input:file entries from ajax's settings.data
