### PR TITLE
Fixes issue with borked rendered HTML

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -13,7 +13,8 @@ module Remotipart
     def render_with_remotipart *args
       render_without_remotipart *args
       if remotipart_submitted?
-        response.body = %{<textarea data-type=\"#{content_type}\" response-code=\"#{response.response_code}\">#{escape_once(response.body)}</textarea>}
+        #response.body = %{<textarea data-type=\"#{content_type}\" response-code=\"#{response.response_code}\">#{escape_once(response.body)}</textarea>}
+        response.body = %{<textarea data-type=\"#{content_type}\" response-code=\"#{response.response_code}\">#{response.body}</textarea>}
         response.content_type = Mime::HTML
       end
       response_body


### PR DESCRIPTION
Would be glad to see a simpler alternative, but this was the only way I could figure out how to prevent erb rendered HMTL within a remotipart controller js.erb to not be double escaped.
