### PR TITLE
Adding the RedirectToOverrides to enable redirect_to also for remotipart submitted actions.

### DIFF
--- a/lib/remotipart.rb
+++ b/lib/remotipart.rb
@@ -1,5 +1,6 @@
 require 'remotipart/view_helper'
 require 'remotipart/request_helper'
 require 'remotipart/render_overrides'
+require 'remotipart/redirect_to_overrides'
 require 'remotipart/middleware'
 require 'remotipart/rails' if defined?(Rails)

--- a/lib/remotipart/rails/engine.rb
+++ b/lib/remotipart/rails/engine.rb
@@ -11,6 +11,7 @@ module Remotipart
       initializer "remotipart.controller_helper" do
         ActionController::Base.send :include, RequestHelper
         ActionController::Base.send :include, RenderOverrides
+        ActionController::Base.send :include, RedirectToOverrides
       end
 
       initializer "remotipart.include_middelware" do

--- a/lib/remotipart/rails/railtie.rb
+++ b/lib/remotipart/rails/railtie.rb
@@ -30,6 +30,7 @@ module Remotipart
       initializer "remotipart.controller_helper" do
         ActionController::Base.send :include, RequestHelper
         ActionController::Base.send :include, RenderOverrides
+        ActionController::Base.send :include, RedirectToOverrides
       end
 
       initializer "remotipart.include_middelware" do

--- a/lib/remotipart/redirect_to_overrides.rb
+++ b/lib/remotipart/redirect_to_overrides.rb
@@ -1,0 +1,38 @@
+# Overriding the redirect_to for Remotipart. Redirecting the received 'text/html' request to the 'js' format.
+require 'uri'
+
+module Remotipart
+  module RedirectToOverrides
+    include ERB::Util
+
+    def self.included(base)
+      base.class_eval do
+        alias_method_chain :redirect_to, :remotipart
+      end
+    end
+
+    def set_url_format(url, format = :js)
+      uri, extn = URI.parse(url), '.' + format.to_s
+      path_fragments = uri.path.split('/')
+      last_fragment  = path_fragments.pop
+      last_fragment.concat(extn) unless last_fragment.ends_with?(extn)
+      uri.path = path_fragments.push(last_fragment).join('/')
+      uri.to_s
+    end
+
+    def redirect_to_with_remotipart *args
+      if remotipart_submitted?
+        case redirect_path = args.shift
+          when Hash
+            redirect_path.merge!(format: :js)
+          when String
+            redirect_path = set_url_format(redirect_path, :js)
+        end
+        args.unshift(redirect_path)
+      end
+
+      redirect_to_without_remotipart *args
+      response.body
+    end
+  end
+end

--- a/remotipart.gemspec
+++ b/remotipart.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
     "lib/remotipart/rails/railtie.rb",
     "lib/remotipart/rails/version.rb",
     "lib/remotipart/render_overrides.rb",
+    "lib/remotipart/redirect_to_overrides.rb",
     "lib/remotipart/request_helper.rb",
     "lib/remotipart/view_helper.rb",
     "remotipart.gemspec",


### PR DESCRIPTION
Currently, remotipart only allows us to render partials with ajax forms having file uploads. This PR provides a class 'RedirectToOverrides' similar to existing 'RenderOverrides' that can handle 'redirect_to' in case of file uploads done via remotipart.
