### PR TITLE
Fire an event (ajax:remotipartComplete) when the ajax upload completes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -65,7 +65,13 @@ make sure you have a supported jquery-ujs (rails.js or jquery_ujs.js) version fr
       $(form).bind("ajax:success", function(){
         if ( $(this).data('remotipartSubmitted') )
       });
+* If you want to be notified when the upload is complete (which can be either success or error)
+  * from your javascript:
 
+      $(form).on("ajax:remotipartComplete", function(e, data){
+        console.log(e, data)
+      });
+      
 === Example
 
 sample_layout.html.erb

--- a/vendor/assets/javascripts/jquery.remotipart.js
+++ b/vendor/assets/javascripts/jquery.remotipart.js
@@ -51,7 +51,9 @@
           // Allow remotipartSubmit to be cancelled if needed
           if ($.rails.fire(form, 'ajax:remotipartSubmit', [xhr, settings])) {
             // Second verse, same as the first
-            $.rails.ajax(settings);
+            $.rails.ajax(settings).complete(function(data){
+              $.rails.fire(form, 'ajax:remotipartComplete', [data]);
+            });
             setTimeout(function(){ $.rails.disableFormElements(form); }, 20);
           }
 


### PR DESCRIPTION
This change will fire an event (`ajax:remotipartComplete`) when the upload completes (i.e. fails or succeeds).

I was having trouble hooking in to remotipart from my javascript. Not sure if it was a Rails 4 thing, or just my wanting to render plain ole JSON, not create.js.erb. 

Anyhoo, I'm going to use this change, as now I can do the following:

`app/assets/javascripts/application.js`

    $(form).on("ajax:remotipartComplete", function(e, data){
       console.log(e, data)
       // or
       // object_json = JSON.parse(data.responseText);
    });