### PR TITLE
Fix issue #61.

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -14,7 +14,7 @@ module Remotipart
       render_without_remotipart *args
       if remotipart_submitted?
         textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
-        response.body = %{<textarea data-type=\"#{response.content_type}\" data-status=\"#{response.response_code}\" data-statusText=\"#{response.message}\">#{textarea_body}</textarea>}
+        response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script> <textarea data-type=\"#{response.content_type}\" data-status=\"#{response.response_code}\" data-statusText=\"#{response.message}\">#{textarea_body}</textarea>}
         response.content_type = Mime::HTML
       end
       response_body


### PR DESCRIPTION
This PR fixes the issue when submitting via `remotipart` doesn't work with subdomains. The exact problem was:

````
Uncaught SecurityError: Blocked a frame with origin "http://subdomain.lvh.me:3000" from accessing a frame with origin "http://subdomain.lvh.me:3000". 
The frame requesting access set "document.domain" to "newinbox.lvh.me", but the frame being accessed did not. Both must set "document.domain" to the same value to allow access.
````
The solution is mentioned on [MDN (Mozilla Developer Network)](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy). 

![solution](https://cloud.githubusercontent.com/assets/1156865/3834694/3aa654fe-1db4-11e4-88cc-3ae38cdb3f7e.png)

##### Why a "Try/Catch"?
That solution actually solves the subdomain issue, but it breaks when there is no subdomain,  so we need to set  `document.domain=document.domain` only when the iframe doesn't have access to the parent and vice versa (equals to having a subdomain).