### PR TITLE
Mention the license type by name to keep lawyers happy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+============================================
+Remotipart is licensed under the MIT License
+============================================
+
 Copyright (c) 2009 Greg Leppert
 
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
We use parts of this library [at Google](https://github.com/reciprocity/ggrc-core) and need to ensure FOSS compliance.
