### PR TITLE
removing the textarea wrapper to fix issue #98

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -12,11 +12,6 @@ module Remotipart
 
     def render_with_remotipart *args
       render_without_remotipart *args
-      if remotipart_submitted?
-        textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
-        response.body = %{<textarea data-type=\"#{response.content_type}\" data-status=\"#{response.response_code}\" data-statusText=\"#{response.message}\">#{textarea_body}</textarea>}
-        response.content_type = Mime::HTML
-      end
       response_body
     end
   end


### PR DESCRIPTION
What is the point of the code I removed? From what I can see all it does is make the js response invalid. If you're submitting via remote="true" you would want a javascript response, not a text/html response. If you're not using remote='true' then you wouldn't need remotipart in the first place. Fixes issue #98 