### PR TITLE
Fix ActionDispatch::IllegalStateError (header already sent). Change Mime::HTML for Mime[:html]

### DIFF
--- a/lib/remotipart/rails/engine.rb
+++ b/lib/remotipart/rails/engine.rb
@@ -14,7 +14,11 @@ module Remotipart
       end
 
       initializer "remotipart.include_middelware" do
-        config.app_middleware.insert_after ActionDispatch::ParamsParser, Middleware
+         if ::Rails.version >= '5'
+          config.app_middleware.use Middleware
+        else
+          config.app_middleware.insert_after ActionDispatch::ParamsParser, Middleware
+        end
       end
     end
 

--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -7,6 +7,13 @@ module Remotipart
     def self.included(base)
       base.class_eval do
         alias_method_chain :render, :remotipart
+        before_action :set_response_content_type
+      end
+    end
+
+    def set_response_content_type
+      if remotipart_submitted?
+        response.content_type = Mime[:html]
       end
     end
 
@@ -15,7 +22,6 @@ module Remotipart
       if remotipart_submitted?
         textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
         response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script>#{textarea_body}}
-        response.content_type = Mime::HTML
       end
       response_body
     end


### PR DESCRIPTION
Fixe the ActionDispatch::IllegalStateError (header already sent) error produced by changing the response type on line 18 of the render_with_remotipart method, which also was using a deprecated way to access mime types.

The error didn't prevented the library from uploading the file, but did produced an error at the response moment which prevented the response for being properly executed

Note: I have manually tested the changes but I don't have enough knowledge on AJAX testing to create automatic tests, also it's possible that my solution is not "the rails way" as this is my first public contribution. 
