### PR TITLE
Rescue Rack::Request.new(env).params Call

### DIFF
--- a/lib/remotipart/middleware.rb
+++ b/lib/remotipart/middleware.rb
@@ -12,8 +12,8 @@ module Remotipart
       begin
         params = Rack::Request.new(env).params
       rescue TypeError => e
-        logger.error e.message
-        logger.error e.backtrace.join("\n")
+        ::Rails.logger.warn e.message
+        ::Rails.logger.warn e.backtrace.join("\n")
       end
 
       if params

--- a/lib/remotipart/middleware.rb
+++ b/lib/remotipart/middleware.rb
@@ -11,7 +11,9 @@ module Remotipart
       # Get request params
       begin
         params = Rack::Request.new(env).params
-      rescue
+      rescue TypeError => e
+        logger.error e.message
+        logger.error e.backtrace.join("\n")
       end
 
       if params

--- a/lib/remotipart/middleware.rb
+++ b/lib/remotipart/middleware.rb
@@ -1,6 +1,6 @@
 module Remotipart
 
-  # A middleware to look for our form parameters and 
+  # A middleware to look for our form parameters and
   # encourage Rails to respond with the requested format
   class Middleware
     def initialize app
@@ -9,7 +9,10 @@ module Remotipart
 
     def call env
       # Get request params
-      params = Rack::Request.new(env).params
+      begin
+        params = Rack::Request.new(env).params
+      rescue
+      end
 
       if params
         # This was using an iframe transport, and is therefore an XHR


### PR DESCRIPTION
When Rack::Request.new(env).params is called with a request that has no
data the following exception is thrown:

> TypeErrorPOST /api/post_receipt_data
> no implicit conversion of nil into Hash

The issue is explained with some more details here: https://github.com/JangoSteve/remotipart/issues/142