### PR TITLE
Fixed deprecation warning for mime types

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -15,7 +15,7 @@ module Remotipart
       if remotipart_submitted?
         textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
         response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script>#{textarea_body}}
-        response.content_type = Mime::HTML
+        response.content_type = Mime[:html]
       end
       response_body
     end


### PR DESCRIPTION
Rails 5.0.0.beta4 will log this deprecation warning.
> DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::HTML` to `Mime[:html]`. (called from render_with_remotipart at ~/gems/remotipart-3a6acb36d46d/lib/remotipart/render_overrides.rb:18)

This pull request fixes the warning.