### PR TITLE
Rails 5 no longer instantiates ActionDispatch::ParamsParser

### DIFF
--- a/lib/remotipart/rails/engine.rb
+++ b/lib/remotipart/rails/engine.rb
@@ -14,7 +14,13 @@ module Remotipart
       end
 
       initializer "remotipart.include_middelware" do
-        config.app_middleware.insert_after ActionDispatch::ParamsParser, Middleware
+        if ::Rails.version >= '5'
+          # Rails 5 no longer instantiates ActionDispatch::ParamsParser
+          # https://github.com/rails/rails/commit/a1ced8b52ce60d0634e65aa36cb89f015f9f543d
+          config.app_middleware.use Middleware
+        else
+          config.app_middleware.insert_after ActionDispatch::ParamsParser, Middleware
+        end
       end
     end
 

--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -6,7 +6,9 @@ module Remotipart
 
     def self.included(base)
       base.class_eval do
-        alias_method_chain :render, :remotipart
+        # Use neither alias_method_chain nor prepend for compatibility
+        alias render_without_remotipart render
+        alias render render_with_remotipart
       end
     end
 
@@ -15,7 +17,7 @@ module Remotipart
       if remotipart_submitted?
         textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
         response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script>#{textarea_body}}
-        response.content_type = Mime::HTML
+        response.content_type = ::Rails.version >= '5' ? Mime[:html] : Mime::HTML
       end
       response_body
     end


### PR DESCRIPTION
Hi! This wasn't created by me, but solves an issue with Rails 5 and remotipart.

Original fork: https://github.com/mshibuya/remotipart/commit/3a6acb36d46d6769faba6bd94ed7f831321f6c6a

In Rails 5, params parser middleware is no longer instantiated automatically. 
https://github.com/rails/rails/commit/a1ced8b52ce60d0634e65aa36cb89f015f9f543d