### PR TITLE
Restore response textarea wrapping

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -14,7 +14,7 @@ module Remotipart
       render_without_remotipart *args
       if remotipart_submitted?
         textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
-        response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script>#{textarea_body}}
+        response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script> <textarea data-type=\"#{response.content_type}\" data-status=\"#{response.response_code}\" data-statusText=\"#{response.message}\">#{textarea_body}</textarea>}
         response.content_type = Mime::HTML
       end
       response_body


### PR DESCRIPTION
This PR restores wrapping of the response to remotipart request into textarea.
The bug was introduced by merge https://github.com/JangoSteve/remotipart/commit/c08d61137ee18e0e78eb3cd9ca3030479fd101f1 - [diff](https://github.com/JangoSteve/remotipart/commit/c08d61137ee18e0e78eb3cd9ca3030479fd101f1#diff-5f515992dd9e54741d37c26537a88b01R17).