### PR TITLE
Make Firefox `load` again

### DIFF
--- a/vendor/assets/javascripts/jquery.iframe-transport.js
+++ b/vendor/assets/javascripts/jquery.iframe-transport.js
@@ -121,7 +121,7 @@
       });
       form.remove();
       iframe.bind("load", function() { iframe.remove(); });
-      iframe.attr("src", "javascript:false;");
+      iframe.attr("src", "about:blank;");
     }
 
     // Remove "iframe" from the data types list so that further processing is
@@ -178,7 +178,7 @@
         // The `send` function is called by jQuery when the request should be
         // sent.
         send: function(headers, completeCallback) {
-          iframe = $("<iframe src='javascript:false;' name='" + name +
+          iframe = $("<iframe src='about:blank;' name='" + name +
             "' id='" + name + "' style='display:none'></iframe>");
 
           // The first load event gets fired after the iframe has been injected


### PR DESCRIPTION
Firefox 49 changed their behavior such that `<iframe>`s with invalid `src` attributes never fire `load` events. This causes remotipart and its `src="javascript:false"` to never finish its setup, and because remotipart has already cancelled the `ajax:aborted:file` event, no submission is ever sent to the server.

This changes the `src` to the more-standard `about:blank`, which makes Firefox send `load` events like it used to.

Note that I also reported this bug to Mozilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1307283