### PR TITLE
⚠️ `*' interpreted as argument prefix

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -13,7 +13,7 @@ module Remotipart
     end
 
     def render_with_remotipart *args
-      render_without_remotipart *args
+      render_without_remotipart(*args)
       if remotipart_submitted?
         textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
         response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script> <textarea data-type=\"#{response.content_type}\" data-status=\"#{response.response_code}\" data-statusText=\"#{response.message}\">#{textarea_body}</textarea>}


### PR DESCRIPTION
Here's a fix for a trivial ⚠️.