### PR TITLE
Fix multi file fields disappear bug when error

### DIFF
--- a/vendor/assets/javascripts/jquery.iframe-transport.js
+++ b/vendor/assets/javascripts/jquery.iframe-transport.js
@@ -117,8 +117,8 @@
     function cleanUp() {
       markers.each(function(i){
         $(this).replaceWith(files[i]);
-        markers.splice(i, 1);
       });
+      markers.splice(0, markers.length);
       form.remove();
       iframe.bind("load", function() { iframe.remove(); });
       iframe.attr("src", "about:blank");


### PR DESCRIPTION
I met bug using multi file fields with remotipart.
Example application is https://github.com/znz/upload-files-test .

I investigated the bug, `markers.splice(i, 1);` in `markers.each` makes iterating with `[post_attachment, post_attachment2, post_attachment3]`, `[post_attachment2, post_attachment3]`, `[post_attachment2]`.
So I think `splice` should be after `each`.
