### PR TITLE
Add license to gemspec

### DIFF
--- a/remotipart.gemspec
+++ b/remotipart.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
     "vendor/assets/javascripts/jquery.remotipart.js"
   ]
   s.homepage = "http://opensource.alfajango.com/remotipart/"
+  s.license = "MIT"
   s.rubygems_version = "2.5.1"
   s.summary = "Remotipart is a Ruby on Rails gem enabling remote multipart forms (AJAX style file uploads) with jquery-rails."
 


### PR DESCRIPTION
This PR adds license item to gemspec. This item is used as follows.

- Describing LICENSES on rubygems.org (https://rubygems.org/gems/remotipart)
- List of licenses displayed by `bundle licenses` command

This will increase the opportunity for users to learn about license.
