### PR TITLE
Fix RJS templates broken by render_with_remotipart alias

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -12,8 +12,8 @@ module Remotipart
       end
     end
 
-    def render_with_remotipart *args
-      render_without_remotipart(*args)
+    def render_with_remotipart(*args, &block)
+      render_without_remotipart(*args, &block)
       if remotipart_submitted?
         textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
         response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script> <textarea data-type=\"#{response.content_type}\" data-status=\"#{response.response_code}\" data-statusText=\"#{response.message}\">#{textarea_body}</textarea>}


### PR DESCRIPTION
RJS templates require a block to be passed to render, but the method signature for `render_with_remotipart` does not support being passed a block.