### PR TITLE
Use prepend instead of alias

### DIFF
--- a/lib/remotipart.rb
+++ b/lib/remotipart.rb
@@ -1,5 +1,9 @@
 require 'remotipart/view_helper'
 require 'remotipart/request_helper'
-require 'remotipart/render_overrides'
+if Module.method_defined? :prepend
+  require 'remotipart/render_prepend'
+else
+  require 'remotipart/render_overrides'
+end
 require 'remotipart/middleware'
 require 'remotipart/rails' if defined?(Rails)

--- a/lib/remotipart/rails/engine.rb
+++ b/lib/remotipart/rails/engine.rb
@@ -10,7 +10,11 @@ module Remotipart
 
       initializer "remotipart.controller_helper" do
         ActionController::Base.send :include, RequestHelper
-        ActionController::Base.send :include, RenderOverrides
+        if Module.method_defined? :prepend
+          ActionController::Base.send :prepend, RenderPrepend
+        else
+          ActionController::Base.send :include, RenderOverrides
+        end
       end
 
       initializer "remotipart.include_middelware" do

--- a/lib/remotipart/render_prepend.rb
+++ b/lib/remotipart/render_prepend.rb
@@ -1,0 +1,17 @@
+module Remotipart
+  # Responder used to automagically wrap any non-xml replies in a text-area
+  # as expected by iframe-transport.
+  module RenderPrepend
+    include ERB::Util
+
+    def render *args
+      super(*args)
+      if remotipart_submitted?
+        textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
+        response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script> <textarea data-type=\"#{response.content_type}\" data-status=\"#{response.response_code}\" data-statusText=\"#{response.message}\">#{textarea_body}</textarea>}
+        response.content_type = ::Rails.version >= '5' ? Mime[:html] : Mime::HTML
+      end
+      response_body
+    end
+  end
+end


### PR DESCRIPTION
Rails 5 deprecates `alias_method_chain`, so I think using `prepend` instead of `alias`es is recommended.