### PR TITLE
Use lazy load hooks to hook on ActionController::Base

### DIFF
--- a/lib/remotipart/rails/railtie.rb
+++ b/lib/remotipart/rails/railtie.rb
@@ -23,13 +23,17 @@ module Remotipart
       end
 
       initializer "remotipart.view_helper" do
-        ActionView::Base.send :include, RequestHelper
-        ActionView::Base.send :include, ViewHelper
+        ActiveSupport.on_load(:action_view) do
+          include RequestHelper
+          include ViewHelper
+        end
       end
 
       initializer "remotipart.controller_helper" do
-        ActionController::Base.send :include, RequestHelper
-        ActionController::Base.send :include, RenderOverrides
+        ActiveSupport.on_load(:action_controller) do
+          include RequestHelper
+          include RenderOverrides
+        end
       end
 
       initializer "remotipart.include_middelware" do


### PR DESCRIPTION
Hello guys 👋 

Use lazy load hooks to hook on ActionController::Base:

- Calling directly ActionController::Base affects the initialization process (one of them being one that controls ActionController configuration)
- As a result setting configuration inside an initializer (such as the asset_host), doesn't have any effect

cc/ @haani @rafaelfranca