### PR TITLE
Use ajax.done instead of deprecated ajax.complete

### DIFF
--- a/vendor/assets/javascripts/jquery.remotipart.js
+++ b/vendor/assets/javascripts/jquery.remotipart.js
@@ -51,9 +51,15 @@
           // Allow remotipartSubmit to be cancelled if needed
           if ($.rails.fire(form, 'ajax:remotipartSubmit', [xhr, settings])) {
             // Second verse, same as the first
-            $.rails.ajax(settings).complete(function(data){
+            var ajax = $.rails.ajax(settings);
+            var fireComplete = function(data){
               $.rails.fire(form, 'ajax:remotipartComplete', [data]);
-            });
+            };
+            if (ajax.complete) {
+              ajax.complete(fireComplete);
+            } else {
+              ajax.always(fireComplete);
+            }
             setTimeout(function(){ $.rails.disableFormElements(form); }, 20);
           }
 


### PR DESCRIPTION
As it turns out... `$.ajax.complete` has been deprecated for a while.
We just upgraded jQuery and it's now gone.

This PR should help moving towards Rails5 and more modern jQuery support.