### PR TITLE
Return Rails's standard value for `render` in `render_with_remotipart`.

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -13,13 +13,15 @@ module Remotipart
     end
 
     def render_with_remotipart(*args, &block)
-      render_without_remotipart(*args, &block)
+      render_return_value = render_without_remotipart(*args, &block)
       if remotipart_submitted?
         textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
         response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script> <textarea data-type=\"#{response.content_type}\" data-status=\"#{response.response_code}\" data-statusText=\"#{response.message}\">#{textarea_body}</textarea>}
         response.content_type = ::Rails.version >= '5' ? Mime[:html] : Mime::HTML
+        response_body
+      else
+        render_return_value
       end
-      response_body
     end
   end
 end


### PR DESCRIPTION
The alias method chain for `render` is not quite right. The return value of `response_body` [here](https://github.com/JangoSteve/remotipart/blob/ed507d21e309f95443cb7b76cc2396e0839cab1e/lib/remotipart/render_overrides.rb#L22) is not the same as `render_without_remotipart` [here](https://github.com/JangoSteve/remotipart/blob/ed507d21e309f95443cb7b76cc2396e0839cab1e/lib/remotipart/render_overrides.rb#L16). Rails's standard `render` call returns a string while `response_body` returns an array. This PR makes it so that it does not alter Rails's standard behavior of returning a string.

I first noticed this in a project that relied on the return value of `render` which suddenly broke when I installed `rails_admin`, which includes this gem.

I started to test this, but ran into firefox binary installation issues and ran out of time. Hope you can forgive me for that.