### PR TITLE
Add frozen_string_literal: true magic comment, fix some coding style

### DIFF
--- a/lib/remotipart.rb
+++ b/lib/remotipart.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'remotipart/view_helper'
 require 'remotipart/request_helper'
 require 'remotipart/render_overrides'

--- a/lib/remotipart/middleware.rb
+++ b/lib/remotipart/middleware.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 module Remotipart
 
   # A middleware to look for our form parameters and
   # encourage Rails to respond with the requested format
   class Middleware
-    def initialize app
+    def initialize(app)
       @app = app
     end
 
-    def call env
+    def call(env)
       # Get request params
       begin
         params = Rack::Request.new(env).params

--- a/lib/remotipart/rails.rb
+++ b/lib/remotipart/rails.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module Remotipart
   module Rails
-    if ::Rails.version.to_s < "3.1"
+    if ::Rails.version.to_s < '3.1'
       require 'remotipart/rails/railtie'
     else
       require 'remotipart/rails/engine'

--- a/lib/remotipart/rails/engine.rb
+++ b/lib/remotipart/rails/engine.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 # Configure Rails 3.1
 module Remotipart
   module Rails
 
     class Engine < ::Rails::Engine
-      initializer "remotipart.view_helper" do
+      initializer 'remotipart.view_helper' do
         ActionView::Base.send :include, RequestHelper
         ActionView::Base.send :include, ViewHelper
       end
 
-      initializer "remotipart.controller_helper" do
+      initializer 'remotipart.controller_helper' do
         ActionController::Base.send :include, RequestHelper
         ActionController::Base.send :include, RenderOverrides
       end
 
-      initializer "remotipart.include_middelware" do
+      initializer 'remotipart.include_middelware' do
         if ::Rails.version >= '5'
           # Rails 5 no longer instantiates ActionDispatch::ParamsParser
           # https://github.com/rails/rails/commit/a1ced8b52ce60d0634e65aa36cb89f015f9f543d

--- a/lib/remotipart/rails/railtie.rb
+++ b/lib/remotipart/rails/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Configure Rails 3.0 to use form.js and remotipart
 module Remotipart
   module Rails
@@ -5,7 +7,7 @@ module Remotipart
     class Railtie < ::Rails::Railtie
       config.before_configuration do
         # Files to be added to :defaults
-        FILES = ['jquery.iframe-transport', 'jquery.remotipart']
+        FILES = ['jquery.iframe-transport', 'jquery.remotipart'].freeze
 
         # Figure out where rails.js (aka jquery_ujs.js if install by jquery-rails gem) is
         # in the :defaults array
@@ -22,21 +24,21 @@ module Remotipart
         end
       end
 
-      initializer "remotipart.view_helper" do
+      initializer 'remotipart.view_helper' do
         ActiveSupport.on_load(:action_view) do
           include RequestHelper
           include ViewHelper
         end
       end
 
-      initializer "remotipart.controller_helper" do
+      initializer 'remotipart.controller_helper' do
         ActiveSupport.on_load(:action_controller) do
           include RequestHelper
           include RenderOverrides
         end
       end
 
-      initializer "remotipart.include_middelware" do
+      initializer 'remotipart.include_middelware' do
         config.app_middleware.insert_after ActionDispatch::ParamsParser, Middleware
       end
     end

--- a/lib/remotipart/rails/version.rb
+++ b/lib/remotipart/rails/version.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module Remotipart
   module Rails
-    VERSION = "1.4.2"
-    IFRAMETRANSPORT_VERSION = "02.06.2013"
+    VERSION = '1.4.2'
+    IFRAMETRANSPORT_VERSION = '02.06.2013'
   end
 end

--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Remotipart
   # Responder used to automagically wrap any non-xml replies in a text-area
   # as expected by iframe-transport.

--- a/lib/remotipart/request_helper.rb
+++ b/lib/remotipart/request_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Remotipart
   module RequestHelper
     def remotipart_submitted?
@@ -5,7 +7,7 @@ module Remotipart
     rescue
       false
     end
-    
+
     alias :remotipart_requested? :remotipart_submitted?
   end
 end

--- a/lib/remotipart/view_helper.rb
+++ b/lib/remotipart/view_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Remotipart
   module ViewHelper
 
@@ -10,9 +12,9 @@ module Remotipart
     end
     alias_method :j, :escape_javascript
 
-    #No longer used
-    #Retrained to prevent issues while updating
-    def remotipart_response(options = {}, &block)
+    # No longer used
+    # Retrained to prevent issues while updating
+    def remotipart_response(_options = {}, &block)
       with_output_buffer(&block)
     end
 


### PR DESCRIPTION
Hi!

This PR adds `#frozen_string_literal: true magic comment` that freezes literal strings in files.
This should help to gain some performance especially in `https://github.com/JangoSteve/remotipart/blob/master/lib/remotipart/middleware.rb`.
I don't know how it's possible but Skylight reports me an average of 55,727 allocations in ` Remotipart::Middleware`.
Thank you!