### PR TITLE
Fix cross-site scripting vulnerability when server renders user input.

### DIFF
--- a/lib/remotipart/render_overrides.rb
+++ b/lib/remotipart/render_overrides.rb
@@ -3,6 +3,7 @@ module Remotipart
   # as expected by iframe-transport.
   module RenderOverrides
     include ERB::Util
+    include ActionView::Helpers::JavaScriptHelper
 
     def self.included(base)
       base.class_eval do
@@ -15,8 +16,7 @@ module Remotipart
     def render_with_remotipart(*args, &block)
       render_return_value = render_without_remotipart(*args, &block)
       if remotipart_submitted?
-        textarea_body = response.content_type == 'text/html' ? html_escape(response.body) : response.body
-        response.body = %{<script type=\"text/javascript\">try{window.parent.document;}catch(err){document.domain=document.domain;}</script> <textarea data-type=\"#{response.content_type}\" data-status=\"#{response.response_code}\" data-statusText=\"#{response.message}\">#{textarea_body}</textarea>}
+        response.body = %{<script type="text/javascript">try{window.parent.document;}catch(err){document.domain=document.domain;}</script><textarea data-type="#{response.content_type}" data-status="#{response.response_code}" data-statusText="#{response.message}"></textarea><script type="text/javascript">document.querySelector("textarea").value="#{escape_javascript(response.body)}";</script>}
         response.content_type = ::Rails.version >= '5' ? Mime[:html] : Mime::HTML
         response_body
       else

--- a/lib/remotipart/view_helper.rb
+++ b/lib/remotipart/view_helper.rb
@@ -1,15 +1,6 @@
 module Remotipart
   module ViewHelper
 
-    def escape_javascript(javascript)
-      if remotipart_submitted?
-        super("#{javascript}")
-      else
-        super
-      end
-    end
-    alias_method :j, :escape_javascript
-
     #No longer used
     #Retrained to prevent issues while updating
     def remotipart_response(options = {}, &block)

--- a/vendor/assets/javascripts/jquery.iframe-transport.js
+++ b/vendor/assets/javascripts/jquery.iframe-transport.js
@@ -210,7 +210,6 @@
                 status = textarea && textarea.getAttribute("data-status") || 200,
                 statusText = textarea && textarea.getAttribute("data-statusText") || "OK",
                 content = {
-                  html: root.innerHTML,
                   text: type ?
                     textarea.value :
                     root ? (root.textContent || root.innerText) : null


### PR DESCRIPTION
@mshibuya Can you please take a look a this and merge it in? I want to allow you to do the merge and release, since you've been keeping up to date with remotipart. This fixes an XSS vulnerability that can sometimes happen if an app has an endpoint that echo's back unescaped user input. This can sometimes happen for example if the app echo's back the user's unescaped input as plain text which doesn't pose any issues for the app. It's possible to manipulate Remotipart into changing the response-type to HTML, which can then execute javascript in the user's input under specific circumstances.

I've also updated the old test suite with a new test for this condition to ensure it doesn't break in the future. Can you please make sure this is added to the PR that adds the test suite directly to this repo?

https://github.com/JangoSteve/Rails-jQuery-Demo/pull/7

Big thanks to Pier-Luc Maltais and @julienfromentc for finding this and working with me by providing a working proof of concept I could test and use to develop a solution.